### PR TITLE
Added notebook for managing mcp servers through llamastack

### DIFF
--- a/demos/rag_agentic/notebooks/extras/mcp_toolgroup_management.ipynb
+++ b/demos/rag_agentic/notebooks/extras/mcp_toolgroup_management.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ef9a663e-5b8e-4968-a74a-4ab8db0a1b1f",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# MCP Management with LlamaStack\n",
+    "\n",
+    "This notebook demonstrates how to manage Model Context Protocol (MCP) toolgroups using the `llama-stack-client`. It offers a hands-on introduction to how MCP allows tools to be dynamically registered and invoked within a llama-stack based system. \n",
+    "\n",
+    "###  What is MCP?\n",
+    "\n",
+    "Model Context Protocol (MCP) is a mechanism that allows agents to interact with tools from a registered endpoint. These MCP tools are used to extend the capabilities of an agent in real time.\n",
+    "\n",
+    "To use MCP tools, you need:\n",
+    "- A running MCP server with a valid endpoint URL.\n",
+    "- An application hosting the MCP client."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f67c1cd-9806-49ec-88f5-16e39dc9030f",
+   "metadata": {},
+   "source": [
+    "## Prerequisites "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48a0f52c-0381-4a51-831c-67fa6be98f3a",
+   "metadata": {},
+   "source": [
+    "Before starting, ensure:\n",
+    "\n",
+    "- You have a running instance of a LlamaStack server ([local](../../../../local_setup_guide.md) or [remote](../../../../kubernetes/)).\n",
+    "- You have configured with the following variables:\n",
+    "  \n",
+    "```\n",
+    "REMOTE_BASE_URL=http://your-llamastack-url\n",
+    "MCP_SERVER_URL=http://your-mcp-url\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4401aba8-d618-4b15-abfc-25719e499e3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from llama_stack_client import LlamaStackClient\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()\n",
+    "\n",
+    "base_url=os.getenv(\"REMOTE_BASE_URL\")\n",
+    "# connecting to remote server\n",
+    "client = LlamaStackClient(base_url=base_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2391984d-4e89-4885-80d3-03d7ce7d76ab",
+   "metadata": {},
+   "source": [
+    "## View Registered tool groups"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "374cf724-695f-4340-a813-02f1466b8925",
+   "metadata": {},
+   "source": [
+    "Refer to this [kubernetes/mcp-servers/](../../../../kubernetes/mcp-servers) to see how to deploy a number of MCP servers on OpenShift.\n",
+    "\n",
+    "To inspect which toolgroups are currently registered with your LlamaStack server, use:\n",
+    "\n",
+    "```\n",
+    "client.toolgroups.list()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "328972fd-7338-4555-9be1-b4ee73fe19d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registered Toolgroups:\n",
+      " - mcp::openshift\n",
+      " - builtin::rag\n",
+      " - mcp::ansible\n",
+      " - mcp::slack\n",
+      " - builtin::code_interpreter\n",
+      " - builtin::websearch\n",
+      " - mcp::github\n"
+     ]
+    }
+   ],
+   "source": [
+    "registered_toolgroups = {tg.identifier for tg in client.toolgroups.list()}\n",
+    "\n",
+    "print(\"Registered Toolgroups:\")\n",
+    "for tg in registered_toolgroups:\n",
+    "    print(f\" - {tg}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e41f432f-50b2-4a14-9ef0-c6e007c7ddb4",
+   "metadata": {},
+   "source": [
+    "## Register an MCP tool group \n",
+    "\n",
+    "Next, we register a new MCP tool group using `client.toolgroups.register(...)`.\n",
+    "\n",
+    "Ensure that the provided MCP endpoint is valid and accessible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "125ad514-cf22-41fe-b89e-43203d21bb6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Register MCP tools\n",
+    "mcp_custom_url = os.getenv(\"CUSTOM_MCP_SERVER_URL\")\n",
+    "if \"mcp::custom_tool\" not in registered_toolgroups:\n",
+    "    client.toolgroups.register(\n",
+    "        toolgroup_id=\"mcp::custom_tool\",\n",
+    "        provider_id=\"model-context-protocol\",\n",
+    "        mcp_endpoint={\"uri\":mcp_custom_url}\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af7c6df2-1299-4d7e-8aa4-cd34f898a13f",
+   "metadata": {},
+   "source": [
+    "### Verify Registered tools\n",
+    "After registering a new MCP tool group, verify its presence by listing all currently registered tool groups using:\n",
+    "\n",
+    "```\n",
+    "client.toolgroups.list()\n",
+    "``` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "df189aaa-eba6-4522-8d2a-c02ab6ee40e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registered Toolgroups:\n",
+      " - mcp::openshift\n",
+      " - builtin::rag\n",
+      " - mcp::custom_tool\n",
+      " - mcp::ansible\n",
+      " - mcp::slack\n",
+      " - builtin::code_interpreter\n",
+      " - builtin::websearch\n",
+      " - mcp::github\n"
+     ]
+    }
+   ],
+   "source": [
+    "registered_toolgroups = {tg.identifier for tg in client.toolgroups.list()}\n",
+    "\n",
+    "print(\"Registered Toolgroups:\")\n",
+    "for tg in registered_toolgroups:\n",
+    "    print(f\" - {tg}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f34d9262-34b2-43fa-808d-85ffccb23e62",
+   "metadata": {},
+   "source": [
+    "You should now see the custom tool group included in the list of registered tool groups."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51094a16-f6e0-40cd-ae2a-5d85f73253b0",
+   "metadata": {},
+   "source": [
+    "##  View Tools in a Tool group"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1b61ac7-7fea-4b18-ae6a-6060789d4f1f",
+   "metadata": {},
+   "source": [
+    "Let us inspect the tools available within a specific tool group, such as `mcp::custom_tool`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ca91c478-58f3-446e-a29d-010935b156f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['generate_random_number', 'approve_score']\n"
+     ]
+    }
+   ],
+   "source": [
+    "tools = client.tools.list(toolgroup_id=\"mcp::custom_tool\")\n",
+    "tool_names = [t.identifier for t in tools]\n",
+    "\n",
+    "print(tool_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da13ca1a-fadf-4cd8-abf2-c89bf1c36a0c",
+   "metadata": {},
+   "source": [
+    "##  Unregistering MCP Tool groups"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "659aadc5-7d34-499e-9880-9625752e641d",
+   "metadata": {},
+   "source": [
+    "If a tool group (e.g., `mcp::custom_tool`) is already registered, you can unregister it to prevent conflicts when re-registering or updating it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fc4d8734-d05d-467f-8c82-fe29616e0ecc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.toolgroups.unregister(toolgroup_id=\"mcp::custom_tool\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cc548db-f7ed-4dd6-9f63-0cb488924b73",
+   "metadata": {},
+   "source": [
+    "To check whether a specific tool group such as `mcp::custom_tool` is currently registered, use the listing command:\n",
+    "\n",
+    "```\n",
+    "client.toolgroups.list()\n",
+    "``` \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5e6fae71-6da1-4cc4-98dd-9b91260c7139",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registered Toolgroups:\n",
+      " - mcp::openshift\n",
+      " - builtin::rag\n",
+      " - mcp::ansible\n",
+      " - mcp::slack\n",
+      " - builtin::code_interpreter\n",
+      " - builtin::websearch\n",
+      " - mcp::github\n"
+     ]
+    }
+   ],
+   "source": [
+    "registered_toolgroups = {tg.identifier for tg in client.toolgroups.list()}\n",
+    "\n",
+    "print(\"Registered Toolgroups:\")\n",
+    "for tg in registered_toolgroups:\n",
+    "    print(f\" - {tg}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc1b5dbb-0ba9-4288-8f63-8bbe87395cd0",
+   "metadata": {},
+   "source": [
+    "As expected, you will no longer see `custom_tool` listed in the registered tool groups after it has been unregistered."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acb26ab2-71cb-496b-ab1d-e8649798f93b",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook, we walked through the process of managing Model Context Protocol (MCP) tool groups within the LlamaStack ecosystem. Here is a step-by-step summary of what we accomplished:\n",
+    "\n",
+    "- **Connected to a LlamaStack server** using environment variables (e.g., `REMOTE_BASE_URL`) to initialize the `llama-stack-client`.\n",
+    "\n",
+    "- **Viewed registered tool groups** to understand the currently available MCP integrations.\n",
+    "\n",
+    "- **Queried tools in a specific group**, such as `mcp::custom_tool`, to explore the capabilities exposed by an MCP server.\n",
+    "\n",
+    "- **Unregistered tool groups** when needed—for instance, before re-registering with an updated endpoint.\n",
+    "\n",
+    "- **Registered a new MCP tool group** using a `toolgroup_id`, specifying the provider type (`model-context-protocol`), and supplying the MCP server URL (`CUSTOM_MCP_SERVER_URL`).\n",
+    "\n",
+    "- **Verified registration** by checking that the tool group appeared in the active tool listing and its tools were accessible to agents."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a notebook showing how to register, unregister, and list MCP toolgroups using llama-stack-client. Useful for managing tool integrations in LlamaStack.
