### PR TITLE
use configmap to define mcp servers

### DIFF
--- a/kubernetes/llama-stack/configmap.yaml
+++ b/kubernetes/llama-stack/configmap.yaml
@@ -157,3 +157,15 @@ data:
       provider_id: rag-runtime
     - toolgroup_id: builtin::code_interpreter
       provider_id: code-interpreter
+    - toolgroup_id: mcp::ansible
+      provider_id: model-context-protocol
+      mcp_endpoint:
+        uri: "http://ansible-mcp-server.llama-serve.svc.cluster.local:8000/sse"
+    - toolgroup_id: mcp::github
+      provider_id: model-context-protocol
+      mcp_endpoint:
+        uri: "http://github-mcp-server-with-rh-nodejs.llama-serve.svc.cluster.local:80/sse"
+    - toolgroup_id: mcp::openshift
+      provider_id: model-context-protocol
+      mcp_endpoint:
+        uri: "http://ocp-mcp-server.llama-serve.svc.cluster.local:8000/sse"

--- a/kubernetes/llama-stack/deployment.yaml
+++ b/kubernetes/llama-stack/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: cache
               mountPath: /.cache
           terminationMessagePolicy: File
-          image: 'quay.io/redhat-et/llama:vllm-0.1.9'
+          image: 'quay.io/redhat-et/llama:vllm-0.2.2'
           args:
             - '--config'
             - /app-config/config.yaml


### PR DESCRIPTION
```
llama-stack-client toolgroups list
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ identifier                ┃ provider_id            ┃ args ┃ mcp_endpoint                                                                                    ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ builtin::code_interpreter │ code-interpreter       │ None │ None                                                                                            │
│ builtin::rag              │ rag-runtime            │ None │ None                                                                                            │
│ builtin::websearch        │ tavily-search          │ None │ None                                                                                            │
│ mcp::ansible              │ model-context-protocol │ None │ McpEndpoint(uri='http://ansible-mcp-server.llama-serve.svc.cluster.local:8000/sse')             │
│ mcp::github               │ model-context-protocol │ None │ McpEndpoint(uri='http://github-mcp-server-with-rh-nodejs.llama-serve.svc.cluster.local:80/sse') │
│ mcp::openshift            │ model-context-protocol │ None │ McpEndpoint(uri='http://ocp-mcp-server.llama-serve.svc.cluster.local:8000/sse')                 │
└───────────────────────────┴────────────────────────┴──────┴─────────────────────────────────────────────────────────────────────────────────────────────────┘
```
