### PR TITLE
updated references to ls 0.2.2 for ocp version draft email

### DIFF
--- a/demos/rag_agentic/notebooks/Level4_agentic_and_mcp.ipynb
+++ b/demos/rag_agentic/notebooks/Level4_agentic_and_mcp.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "### Installing dependencies\n",
     "\n",
-    "This code requires `llama-stack` and the `llama-stack-client`, both at version `0.1.9`. Lets begin by installing them:"
+    "This code requires `llama-stack` and the `llama-stack-client`, both at version `0.2.2`. Lets begin by installing them:"
    ]
   },
   {
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install llama-stack-client==0.1.9 llama-stack==0.1.9"
+    "!pip install llama-stack-client==0.2.2 llama-stack==0.2.2"
    ]
   },
   {


### PR DESCRIPTION
Version bump to work with `v0.2.2`. Everything worked out of the box, just needed to update docs.