### PR TITLE
Change vllm-dashboard name to lowercase

### DIFF
--- a/kubernetes/observability/grafana/vllm-dashboard/vllm-dashboard.yaml
+++ b/kubernetes/observability/grafana/vllm-dashboard/vllm-dashboard.yaml
@@ -1,7 +1,7 @@
 kind: GrafanaDashboard
 apiVersion: grafana.integreatly.org/v1beta1
 metadata:
-  name: vLLM
+  name: vllm
   labels:
     app: grafana
 spec:


### PR DESCRIPTION
when doing `apply -f .../vllm-dashboard.yaml` it fails because the metadata.name of the Custom Resource, the GrafanaDashboard, has to be lowercase only - the name of the dashboard in the Grafana UI still remains as vLLM though.

Closes: https://github.com/opendatahub-io/llama-stack-demos/issues/114