### PR TITLE
removal of tavily for demo env

### DIFF
--- a/kubernetes/kustomize/overlay/demo/kustomization.yaml
+++ b/kubernetes/kustomize/overlay/demo/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  # llama-serve resources
+  - ../../../llama-serve/granite-8b
+  - ../../../llama-serve/llama3.2-3b
+
+patchesStrategicMerge:
+  - remove-tavily-env.yaml

--- a/kubernetes/kustomize/overlay/demo/remove-tavily-env.yaml
+++ b/kubernetes/kustomize/overlay/demo/remove-tavily-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: streamlit
+spec:
+  template:
+    spec:
+      containers:
+      - name: streamlit-client
+        env:
+        - name: TAVILY_SEARCH_API_KEY
+          $patch: delete


### PR DESCRIPTION
We won't be able to directly provide the demo environment a key so we need to remove this once kustomize generates the files
