### PR TITLE
Tutorial review for Notebooks 0, 1 and 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ REMOTE_BASE_URL= "http://localhost:8321"
 TEMPERATURE="0.0"
 TOP_P="0.95"
 MAX_TOKENS="4096"
-STREAM="True"
+STREAM="False"
 
 # for the RAG demos only - mandatory
 VDB_PROVIDER="milvus"

--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,26 @@
 # mandatory environment variables
-INFERENCE_MODEL_ID= ""
+INFERENCE_MODEL_ID= "ibm-granite/granite-3.2-8b-instruct"
 
 # mandatory unless a local deployment is used
-REMOTE_BASE_URL= ""
+REMOTE_BASE_URL= "http://localhost:8321"
 
 # optional environment variables for all demos
-REMOTE=""
-LOCAL_SERVER_PORT=""
-TEMPERATURE=""
-TOP_P=""
-MAX_TOKENS=""
-STREAM=""
+TEMPERATURE="0.0"
+TOP_P="0.95"
+MAX_TOKENS="4096"
+STREAM="True"
 
 # for the RAG demos only - mandatory
-VDB_PROVIDER=""
-VDB_EMBEDDING=""
+VDB_PROVIDER="milvus"
+VDB_EMBEDDING="all-MiniLM-L6-v2"
 
 # for the RAG demos only - optional
-VDB_EMBEDDING_DIMENSION=""
-VECTOR_DB_CHUNK_SIZE=""
+VDB_EMBEDDING_DIMENSION="384"
+VECTOR_DB_CHUNK_SIZE="512"
 
 # for the agentic/tool demos
 TAVILY_SEARCH_API_KEY= ""
-USE_PROMPT_CHAINING= ""
+USE_PROMPT_CHAINING= "True"
 
 # MCP-related
 REMOTE_OCP_MCP_URL= ""

--- a/demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb
+++ b/demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb
@@ -7,11 +7,17 @@
    "source": [
     "# Level 0: Getting Started with Llama Stack\n",
     "\n",
-    "In this tutorial, we will outline the necessary steps to set up your environment and prepare everything you will need in order to execute our sample notebooks as well as create your own Llama Stack client applications. In particular, we will cover installing and importing the necessary libraries, setting up the essential configuration parameters, and initializing the connection to the Llama Stack server. More advanced sections of this notebook address the setup for RAG and MCP applications.\n",
+    "This notebook will help you set up your environment for this tutorial. Specifically, we will cover installing the necessary libraries, configuring essential parameters, and connecting to a Llama Stack server.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
-    "Before starting, ensure you have a running instance of the Llama Stack server (local or remote). You will need at least one preconfigured vector DB to run the RAG notebooks. For detailed llama-stack server setup instructions and for more information, please refer to our [Remote Setup Guide](../../../kubernetes/README.md) and [Local Setup Guide](../../../local_setup_guide.md), as well as to the official [Llama Stack tutorials](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html)."
+    "\n",
+    "Ensure you have access to a [Llama Stack](https://llama-stack.readthedocs.io/en/latest/) server.\n",
+    "\n",
+    "If you need to set one up, please follow the instruction set below that is appropriate for your environment:\n",
+    "\n",
+    "* [Local](../../../local_setup_guide.md) setup guide for a laptop.\n",
+    "* [Remote](../../../kubernetes/README.md) setup guide for an OpenShift cluster."
    ]
   },
   {
@@ -21,7 +27,7 @@
    "source": [
     "## Installing Dependencies\n",
     "\n",
-    "This code requires `llama-stack` and the `llama-stack-client` Lets begin by installing them:"
+    "This code requires `llama-stack` and the `llama-stack-client` python packages. Let's begin by installing them:"
    ]
   },
   {
@@ -29,85 +35,9 @@
    "execution_count": 1,
    "id": "ba0ddc8b-d6cf-4cb3-8678-7b52ee70131e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: llama-stack-client==0.2.4 in /opt/app-root/lib64/python3.11/site-packages (0.2.4)\n",
-      "Requirement already satisfied: llama-stack==0.2.4 in /opt/app-root/lib64/python3.11/site-packages (0.2.4)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (4.8.0)\n",
-      "Requirement already satisfied: click in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (8.1.8)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (0.28.1)\n",
-      "Requirement already satisfied: pandas in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (2.2.3)\n",
-      "Requirement already satisfied: prompt-toolkit in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (3.0.50)\n",
-      "Requirement already satisfied: pyaml in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (25.1.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (2.11.4)\n",
-      "Requirement already satisfied: rich in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (13.9.4)\n",
-      "Requirement already satisfied: sniffio in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (1.3.1)\n",
-      "Requirement already satisfied: termcolor in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (2.3.0)\n",
-      "Requirement already satisfied: tqdm in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (4.67.1)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.7 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack-client==0.2.4) (4.12.2)\n",
-      "Requirement already satisfied: blobfile in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (3.0.0)\n",
-      "Requirement already satisfied: fire in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (0.7.0)\n",
-      "Requirement already satisfied: huggingface-hub in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (0.30.2)\n",
-      "Requirement already satisfied: jinja2>=3.1.6 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (3.1.6)\n",
-      "Requirement already satisfied: jsonschema in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (4.23.0)\n",
-      "Requirement already satisfied: openai>=1.66 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (1.76.2)\n",
-      "Requirement already satisfied: python-dotenv in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (1.1.0)\n",
-      "Requirement already satisfied: requests in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (2.32.3)\n",
-      "Requirement already satisfied: setuptools in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (74.1.3)\n",
-      "Requirement already satisfied: tiktoken in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (0.9.0)\n",
-      "Requirement already satisfied: pillow in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (11.1.0)\n",
-      "Requirement already satisfied: h11>=0.16.0 in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (0.16.0)\n",
-      "Requirement already satisfied: kubernetes in /opt/app-root/lib64/python3.11/site-packages (from llama-stack==0.2.4) (30.1.0)\n",
-      "Requirement already satisfied: idna>=2.8 in /opt/app-root/lib64/python3.11/site-packages (from anyio<5,>=3.5.0->llama-stack-client==0.2.4) (3.10)\n",
-      "Requirement already satisfied: certifi in /opt/app-root/lib64/python3.11/site-packages (from httpx<1,>=0.23.0->llama-stack-client==0.2.4) (2025.1.31)\n",
-      "Requirement already satisfied: httpcore==1.* in /opt/app-root/lib64/python3.11/site-packages (from httpx<1,>=0.23.0->llama-stack-client==0.2.4) (1.0.9)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /opt/app-root/lib64/python3.11/site-packages (from jinja2>=3.1.6->llama-stack==0.2.4) (3.0.2)\n",
-      "Requirement already satisfied: jiter<1,>=0.4.0 in /opt/app-root/lib64/python3.11/site-packages (from openai>=1.66->llama-stack==0.2.4) (0.9.0)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in /opt/app-root/lib64/python3.11/site-packages (from pydantic<3,>=1.9.0->llama-stack-client==0.2.4) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.33.2 in /opt/app-root/lib64/python3.11/site-packages (from pydantic<3,>=1.9.0->llama-stack-client==0.2.4) (2.33.2)\n",
-      "Requirement already satisfied: typing-inspection>=0.4.0 in /opt/app-root/lib64/python3.11/site-packages (from pydantic<3,>=1.9.0->llama-stack-client==0.2.4) (0.4.0)\n",
-      "Requirement already satisfied: pycryptodomex>=3.8 in /opt/app-root/lib64/python3.11/site-packages (from blobfile->llama-stack==0.2.4) (3.22.0)\n",
-      "Requirement already satisfied: urllib3<3,>=1.25.3 in /opt/app-root/lib64/python3.11/site-packages (from blobfile->llama-stack==0.2.4) (1.26.20)\n",
-      "Requirement already satisfied: lxml>=4.9 in /opt/app-root/lib64/python3.11/site-packages (from blobfile->llama-stack==0.2.4) (5.4.0)\n",
-      "Requirement already satisfied: filelock>=3.0 in /opt/app-root/lib64/python3.11/site-packages (from blobfile->llama-stack==0.2.4) (3.17.0)\n",
-      "Requirement already satisfied: fsspec>=2023.5.0 in /opt/app-root/lib64/python3.11/site-packages (from huggingface-hub->llama-stack==0.2.4) (2025.2.0)\n",
-      "Requirement already satisfied: packaging>=20.9 in /opt/app-root/lib64/python3.11/site-packages (from huggingface-hub->llama-stack==0.2.4) (24.2)\n",
-      "Requirement already satisfied: pyyaml>=5.1 in /opt/app-root/lib64/python3.11/site-packages (from huggingface-hub->llama-stack==0.2.4) (6.0.2)\n",
-      "Requirement already satisfied: attrs>=22.2.0 in /opt/app-root/lib64/python3.11/site-packages (from jsonschema->llama-stack==0.2.4) (25.1.0)\n",
-      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /opt/app-root/lib64/python3.11/site-packages (from jsonschema->llama-stack==0.2.4) (2024.10.1)\n",
-      "Requirement already satisfied: referencing>=0.28.4 in /opt/app-root/lib64/python3.11/site-packages (from jsonschema->llama-stack==0.2.4) (0.36.2)\n",
-      "Requirement already satisfied: rpds-py>=0.7.1 in /opt/app-root/lib64/python3.11/site-packages (from jsonschema->llama-stack==0.2.4) (0.22.3)\n",
-      "Requirement already satisfied: six>=1.9.0 in /opt/app-root/lib64/python3.11/site-packages (from kubernetes->llama-stack==0.2.4) (1.17.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.5.3 in /opt/app-root/lib64/python3.11/site-packages (from kubernetes->llama-stack==0.2.4) (2.9.0.post0)\n",
-      "Requirement already satisfied: google-auth>=1.0.1 in /opt/app-root/lib64/python3.11/site-packages (from kubernetes->llama-stack==0.2.4) (2.38.0)\n",
-      "Requirement already satisfied: websocket-client!=0.40.0,!=0.41.*,!=0.42.*,>=0.32.0 in /opt/app-root/lib64/python3.11/site-packages (from kubernetes->llama-stack==0.2.4) (1.8.0)\n",
-      "Requirement already satisfied: requests-oauthlib in /opt/app-root/lib64/python3.11/site-packages (from kubernetes->llama-stack==0.2.4) (2.0.0)\n",
-      "Requirement already satisfied: oauthlib>=3.2.2 in /opt/app-root/lib64/python3.11/site-packages (from kubernetes->llama-stack==0.2.4) (3.2.2)\n",
-      "Requirement already satisfied: numpy>=1.23.2 in /opt/app-root/lib64/python3.11/site-packages (from pandas->llama-stack-client==0.2.4) (2.1.3)\n",
-      "Requirement already satisfied: pytz>=2020.1 in /opt/app-root/lib64/python3.11/site-packages (from pandas->llama-stack-client==0.2.4) (2025.1)\n",
-      "Requirement already satisfied: tzdata>=2022.7 in /opt/app-root/lib64/python3.11/site-packages (from pandas->llama-stack-client==0.2.4) (2025.1)\n",
-      "Requirement already satisfied: wcwidth in /opt/app-root/lib64/python3.11/site-packages (from prompt-toolkit->llama-stack-client==0.2.4) (0.2.13)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /opt/app-root/lib64/python3.11/site-packages (from requests->llama-stack==0.2.4) (3.4.1)\n",
-      "Requirement already satisfied: markdown-it-py>=2.2.0 in /opt/app-root/lib64/python3.11/site-packages (from rich->llama-stack-client==0.2.4) (3.0.0)\n",
-      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /opt/app-root/lib64/python3.11/site-packages (from rich->llama-stack-client==0.2.4) (2.19.1)\n",
-      "Requirement already satisfied: regex>=2022.1.18 in /opt/app-root/lib64/python3.11/site-packages (from tiktoken->llama-stack==0.2.4) (2024.11.6)\n",
-      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /opt/app-root/lib64/python3.11/site-packages (from google-auth>=1.0.1->kubernetes->llama-stack==0.2.4) (5.5.1)\n",
-      "Requirement already satisfied: pyasn1-modules>=0.2.1 in /opt/app-root/lib64/python3.11/site-packages (from google-auth>=1.0.1->kubernetes->llama-stack==0.2.4) (0.4.1)\n",
-      "Requirement already satisfied: rsa<5,>=3.1.4 in /opt/app-root/lib64/python3.11/site-packages (from google-auth>=1.0.1->kubernetes->llama-stack==0.2.4) (4.9)\n",
-      "Requirement already satisfied: mdurl~=0.1 in /opt/app-root/lib64/python3.11/site-packages (from markdown-it-py>=2.2.0->rich->llama-stack-client==0.2.4) (0.1.2)\n",
-      "Requirement already satisfied: pyasn1<0.7.0,>=0.4.6 in /opt/app-root/lib64/python3.11/site-packages (from pyasn1-modules>=0.2.1->google-auth>=1.0.1->kubernetes->llama-stack==0.2.4) (0.6.1)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install llama-stack-client==0.2.4 llama-stack==0.2.4"
+    "! pip install -r requirements.txt > /dev/null"
    ]
   },
   {
@@ -117,18 +47,23 @@
    "source": [
     "## Setting the Environment Variables\n",
     "\n",
-    "Use the [`.env.example`](../../../.env.example) to create a new file called `.env` and ensure you add all the relevant environment variables below.\n",
+    "Rename or copy the [`.env.example`](../../../.env.example) file to create a new file called `.env`. We've included as many reasonable defaults as possible to get you started, but please use this file to make any customizations needed for your environment such as the the location of the Llama Stack server endpoint or your personal [Tavily](https://app.tavily.com) api key for web search.  \n",
     "\n",
+    "```bash\n",
+    "cp .env.example .env\n",
+    "```\n",
     "\n",
     "### Environment variables required for all demos\n",
     "- `REMOTE_BASE_URL`: the URL of the remote Llama Stack server.\n",
     "- `INFERENCE_MODEL_ID`: the ID of the model to use for inference. The model must be available on your server.\n",
-    "- `LOCAL_SERVER_PORT` (optional): the port of the locally running Llama Stack server. Defaults to 8321.\n",
-    "- `REMOTE` (optional): defines whether a locally running or a remote instance of the Llama Stack server should be used. Only the values of 'True' and 'False' are valid. This is useful for switching between a local development environment and a remote deployment (e.g., a Kubernetes cluster). Defaults to True.\n",
     "- `TEMPERATURE` (optional): the temperature to use during inference. Defaults to 0.0.\n",
     "- `TOP_P` (optional): the top_p parameter to use during inference. Defaults to 0.95.\n",
     "- `MAX_TOKENS` (optional): the maximum number of tokens that can be generated in the completion. Defaults to 4096.\n",
-    "- `STREAM` (optional): set this to True to stream the output of the model/agent and False otherwise. Defaults to True."
+    "- `STREAM` (optional): set this to True to stream the output of the model/agent and False otherwise. Defaults to True.\n",
+    "- `VDB_PROVIDER`: the vector DB provider to be used. Must be supported by Llama Stack. For this demo, we use Milvus Lite which is our preferred solution.\n",
+    "- `VDB_EMBEDDING`: the embedding model to be used for ingestion and retrieval. For this demo, we use all-MiniLM-L6-v2.\n",
+    "- `VDB_EMBEDDING_DIMENSION` (optional): the dimension of the embedding. Defaults to 384.\n",
+    "- `VECTOR_DB_CHUNK_SIZE` (optional): the chunk size for the vector DB. Defaults to 512."
    ]
   },
   {
@@ -168,7 +103,9 @@
    "source": [
     "## Setting Up the Server Connection\n",
     "\n",
-    "Establish the connection to the Llama Stack server by initializing the wrapper client object according to the predefined settings."
+    "Establish the connection to your Llama Stack server.\n",
+    "\n",
+    "_Note: A Tavily search API key is required for some of our demos and must be provided to the client upon initialization. If you do not have one, you can set one up for free at https://app.tavily.com_"
    ]
   },
   {
@@ -181,19 +118,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to Llama Stack server @ http://localhost:8321\n"
+      "Connected to Llama Stack server\n"
      ]
     }
    ],
    "source": [
-    "remote = os.getenv(\"REMOTE\", \"True\")\n",
-    "\n",
-    "if remote == \"False\":\n",
-    "    local_port = os.getenv(\"LOCAL_SERVER_PORT\", 8321)\n",
-    "    base_url = f\"http://localhost:{local_port}\"\n",
-    "else: # any value non equal to 'False' will be considered as 'True'\n",
-    "    base_url = os.getenv(\"REMOTE_BASE_URL\")\n",
-    "\n",
+    "base_url = os.getenv(\"REMOTE_BASE_URL\", \"http://localhost:8321\")\n",
     "\n",
     "# Tavily search API key is required for some of our demos and must be provided to the client upon initialization.\n",
     "# We will cover it in the agentic demos that use the respective tool. Please ignore this parameter for all other demos.\n",
@@ -209,7 +139,7 @@
     "    provider_data=provider_data\n",
     ")\n",
     "\n",
-    "print(f\"Connected to Llama Stack server @ {base_url}\")"
+    "print(f\"Connected to Llama Stack server\")"
    ]
   },
   {
@@ -265,11 +195,21 @@
     "\n",
     "print(f\"Inference Parameters:\\n\\tModel: {model_id}\\n\\tSampling Parameters: {sampling_params}\\n\\tstream: {stream}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6d0a375",
+   "metadata": {},
+   "source": [
+    "# Next\n",
+    "\n",
+    "Now that we've set up our Tutorial environment, Let's get started building with Llama Stack! The next notebook will teach you how to build a [Simple RAG](./Level1_foundational_RAG.ipynb) application."
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.11",
+   "display_name": "mcp",
    "language": "python",
    "name": "python3"
   },
@@ -283,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb
+++ b/demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb
@@ -17,7 +17,7 @@
     "If you need to set one up, please follow the instruction set below that is appropriate for your environment:\n",
     "\n",
     "* [Local](../../../local_setup_guide.md) setup guide for a laptop.\n",
-    "* [Remote](../../../kubernetes/README.md) setup guide for an OpenShift cluster."
+    "* [Remote](../../../kubernetes/llama-stack/README.md) setup guide for an OpenShift cluster."
    ]
   },
   {
@@ -59,7 +59,7 @@
     "- `TEMPERATURE` (optional): the temperature to use during inference. Defaults to 0.0.\n",
     "- `TOP_P` (optional): the top_p parameter to use during inference. Defaults to 0.95.\n",
     "- `MAX_TOKENS` (optional): the maximum number of tokens that can be generated in the completion. Defaults to 4096.\n",
-    "- `STREAM` (optional): set this to True to stream the output of the model/agent and False otherwise. Defaults to True.\n",
+    "- `STREAM` (optional): set this to True to stream the output of the model/agent and False otherwise. Defaults to False.\n",
     "- `VDB_PROVIDER`: the vector DB provider to be used. Must be supported by Llama Stack. For this demo, we use Milvus Lite which is our preferred solution.\n",
     "- `VDB_EMBEDDING`: the embedding model to be used for ingestion and retrieval. For this demo, we use all-MiniLM-L6-v2.\n",
     "- `VDB_EMBEDDING_DIMENSION` (optional): the dimension of the embedding. Defaults to 384.\n",

--- a/demos/rag_agentic/notebooks/Level1_foundational_RAG.ipynb
+++ b/demos/rag_agentic/notebooks/Level1_foundational_RAG.ipynb
@@ -5,31 +5,18 @@
    "id": "45fc9086-93aa-4645-8ba2-380c3acbbed9",
    "metadata": {},
    "source": [
-    "# Level 1: Foundational RAG\n",
+    "# Level 1: Simple RAG\n",
     "\n",
-    "This tutorial presents an example of executing queries with foundational (i.e., non-agentic) RAG in Llama Stack. It shows how the APIs provided by Llama Stack can be used to directly control and invoke all RAG stages, including indexing, retrieval and inference. \n",
-    "For an agentic RAG tutorial, please refer to [Level3_agentic_RAG.ipynb](demos/rag_agentic/notebooks/Level3_agentic_RAG.ipynb).\n",
+    "This notebook will show you how to build a simple RAG application with Llama Stack. You will learn how the API's provided by Llama Stack can be used to directly control and invoke all common RAG stages, including indexing, retrieval and inference. \n",
+    "\n",
+    "_Note: This notebook contains a non-agentic implementation of RAG. We will show you how to build an agentic RAG application later in this tutorial in [Level3_agentic_RAG](demos/rag_agentic/notebooks/Level3_agentic_RAG.ipynb)._\n",
     "\n",
     "## Overview\n",
     "\n",
     "This tutorial covers the following steps:\n",
-    "1. Indexing a collection of documents in a vector DB for later retrieval.\n",
+    "1. Indexing a collection of documents into a vector database for later retrieval.\n",
     "2. Executing the built-in RAG tool to retrieve the document chunks relevant to a given query.\n",
-    "3. Using the retrieved context to answer user queries during the inference step.\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "Before starting, ensure you have a running instance of the Llama Stack server (local or remote) with at least one preconfigured vector DB. For more information, please refer to the corresponding [Llama Stack tutorials](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html).\n",
-    "\n",
-    "## Setting the Environment Variables\n",
-    "\n",
-    "Use the [`.env.example`](../../../.env.example) to create a new file called `.env` and ensure you add all the relevant environment variables below.\n",
-    "\n",
-    "In addition to the environment variables listed in the [\"Getting Started\" notebook](demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb), the following should be provided for this demo to run:\n",
-    " - `VDB_PROVIDER`: the vector DB provider to be used. Must be supported by Llama Stack. For this demo, we use Milvus Lite which is our preferred solution.\n",
-    " - `VDB_EMBEDDING`: the embedding model to be used for ingestion and retrieval. For this demo, we use all-MiniLM-L6-v2.\n",
-    " - `VDB_EMBEDDING_DIMENSION` (optional): the dimension of the embedding. Defaults to 384.\n",
-    " - `VECTOR_DB_CHUNK_SIZE` (optional): the chunk size for the vector DB. Defaults to 512."
+    "3. Using the retrieved context to answer user queries during the inference step."
    ]
   },
   {
@@ -37,8 +24,9 @@
    "id": "6db34e4b-ed29-4007-b760-59543d4caca1",
    "metadata": {},
    "source": [
-    "## 1. Setting Up the Environment\n",
-    "We will start with a few imports needed for this demo only."
+    "## 1. Setting Up this Notebook\n",
+    "\n",
+    "First, we will start with a few imports."
    ]
   },
   {
@@ -66,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "558909bb-955c-40a3-a0c2-1f4acb0dd62e",
    "metadata": {},
    "outputs": [
@@ -74,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to Llama Stack server @ http://localhost:8321\n",
+      "Connected to Llama Stack server\n",
       "Inference Parameters:\n",
       "\tModel: ibm-granite/granite-3.2-8b-instruct\n",
       "\tSampling Parameters: {'strategy': {'type': 'greedy'}, 'max_tokens': 4096}\n",
@@ -97,14 +85,7 @@
     "from src.utils import step_printer\n",
     "from termcolor import cprint\n",
     "\n",
-    "remote = os.getenv(\"REMOTE\", \"True\")\n",
-    "\n",
-    "if remote == \"False\":\n",
-    "    local_port = os.getenv(\"LOCAL_SERVER_PORT\", 8321)\n",
-    "    base_url = f\"http://localhost:{local_port}\"\n",
-    "else: # any value non equal to 'False' will be considered as 'True'\n",
-    "    base_url = os.getenv(\"REMOTE_BASE_URL\")\n",
-    "\n",
+    "base_url = os.getenv(\"REMOTE_BASE_URL\")\n",
     "\n",
     "# Tavily search API key is required for some of our demos and must be provided to the client upon initialization.\n",
     "# We will cover it in the agentic demos that use the respective tool. Please ignore this parameter for all other demos.\n",
@@ -120,7 +101,7 @@
     "    provider_data=provider_data\n",
     ")\n",
     "    \n",
-    "print(f\"Connected to Llama Stack server @ {base_url}\")\n",
+    "print(f\"Connected to Llama Stack server\")\n",
     "\n",
     "# model_id will later be used to pass the name of the desired inference model to Llama Stack Agents/Inference APIs\n",
     "model_id = os.getenv(\"INFERENCE_MODEL_ID\")\n",
@@ -153,7 +134,7 @@
    "id": "841eaadf-f5ac-4d7c-bb9d-f039ccd8d9a3",
    "metadata": {},
    "source": [
-    "Finally, we will initialize the document collection to be used for RAG ingestion and retrieval."
+    "Finally, we complete the setup by initializing the document collection we will use for RAG ingestion and retrieval."
    ]
   },
   {
@@ -174,13 +155,13 @@
    "metadata": {},
    "source": [
     "## 2. Indexing the Documents\n",
-    "- Initialize a new document collection in the target vector DB. All parameters related to the vector DB, such as the embedding model and dimension, must be specified here.\n",
-    "- Provide a list of document URLs to the RAG tool. Llama Stack will handle fetching, conversion and chunking of the documents' content."
+    "- Initialize a new document collection in our vector database. All parameters related to the vector database, such as the embedding model and dimension, must be specified here.\n",
+    "- Provide a list of document URLs to the RAG tool. Llama Stack will handle fetching, converting, and chunking the content of the documents."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "8d81ffb2-2089-4cb8-adae-f32965f206c7",
    "metadata": {
     "tags": []
@@ -221,7 +202,7 @@
    "metadata": {},
    "source": [
     "## 3. Executing Queries via the Built-in RAG Tool\n",
-    "- Directly invoke the RAG tool to query the vector DB we ingested into at the previous stage.\n",
+    "- Directly invoke the RAG tool to query the vector database we ingested into at the previous stage.\n",
     "- Construct an extended prompt using the retrieved chunks.\n",
     "- Query the model with the extended prompt.\n",
     "- Output the reply received from the model."
@@ -229,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "0d39ab00-2a65-4b72-b5ed-4dd61f1204a2",
    "metadata": {
     "tags": []
@@ -240,27 +221,28 @@
      "output_type": "stream",
      "text": [
       "\u001b[34m\n",
-      "User> How to install OpenShift?\u001b[0m\n",
-      "\u001b[33mTo\u001b[0m\u001b[33m install\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m,\u001b[0m\u001b[33m you\u001b[0m\u001b[33m can\u001b[0m\u001b[33m follow\u001b[0m\u001b[33m these\u001b[0m\u001b[33m steps\u001b[0m\u001b[33m:\n",
+      "User> How do I install OpenShift?\u001b[0m\n",
+      "\u001b[33minference> \u001b[0m\u001b[33m\u001b[0m\u001b[33mTo\u001b[0m\u001b[33m install\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m,\u001b[0m\u001b[33m you\u001b[0m\u001b[33m can\u001b[0m\u001b[33m follow\u001b[0m\u001b[33m these\u001b[0m\u001b[33m steps\u001b[0m\u001b[33m:\n",
       "\n",
-      "\u001b[33m.\u001b[0m\u001b[33m **\u001b[0m\u001b[33mDownload\u001b[0m\u001b[33m and\u001b[0m\u001b[33m Install\u001b[0m\u001b[33m the\u001b[0m\u001b[33m oc\u001b[0m\u001b[33m CLI\u001b[0m\u001b[33m Tool\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m You\u001b[0m\u001b[33m need\u001b[0m\u001b[33m to\u001b[0m\u001b[33m download\u001b[0m\u001b[33m and\u001b[0m\u001b[33m install\u001b[0m\u001b[33m the\u001b[0m\u001b[33m `\u001b[0m\u001b[33moc\u001b[0m\u001b[33m`\u001b[0m\u001b[33m command\u001b[0m\u001b[33m-line\u001b[0m\u001b[33m tool\u001b[0m\u001b[33m from\u001b[0m\u001b[33m the\u001b[0m\u001b[33m official\u001b[0m\u001b[33m Red\u001b[0m\u001b[33m Hat\u001b[0m\u001b[33m website\u001b[0m\u001b[33m.\n",
-      "\u001b[33m2\u001b[0m\u001b[33m.\u001b[0m\u001b[33m **\u001b[0m\u001b[33mCreate\u001b[0m\u001b[33m a\u001b[0m\u001b[33m Cluster\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Create\u001b[0m\u001b[33m an\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m cluster\u001b[0m\u001b[33m using\u001b[0m\u001b[33m one\u001b[0m\u001b[33m of\u001b[0m\u001b[33m the\u001b[0m\u001b[33m following\u001b[0m\u001b[33m methods\u001b[0m\u001b[33m:\n",
-      "\u001b[33m*\u001b[0m\u001b[33m **\u001b[0m\u001b[33mMin\u001b[0m\u001b[33mish\u001b[0m\u001b[33mift\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Use\u001b[0m\u001b[33m Min\u001b[0m\u001b[33mish\u001b[0m\u001b[33mift\u001b[0m\u001b[33m,\u001b[0m\u001b[33m a\u001b[0m\u001b[33m tool\u001b[0m\u001b[33m that\u001b[0m\u001b[33m allows\u001b[0m\u001b[33m you\u001b[0m\u001b[33m to\u001b[0m\u001b[33m run\u001b[0m\u001b[33m an\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m cluster\u001b[0m\u001b[33m on\u001b[0m\u001b[33m your\u001b[0m\u001b[33m local\u001b[0m\u001b[33m machine\u001b[0m\u001b[33m.\n",
-      "\u001b[33m*\u001b[0m\u001b[33m **\u001b[0m\u001b[33mOK\u001b[0m\u001b[33mD\u001b[0m\u001b[33m (\u001b[0m\u001b[33mOpen\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m Origin\u001b[0m\u001b[33m)**\u001b[0m\u001b[33m:\u001b[0m\u001b[33m Install\u001b[0m\u001b[33m OK\u001b[0m\u001b[33mD\u001b[0m\u001b[33m,\u001b[0m\u001b[33m which\u001b[0m\u001b[33m is\u001b[0m\u001b[33m an\u001b[0m\u001b[33m open\u001b[0m\u001b[33m-source\u001b[0m\u001b[33m version\u001b[0m\u001b[33m of\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m.\n",
-      "\u001b[33m\t\u001b[0m\u001b[33m*\u001b[0m\u001b[33m **\u001b[0m\u001b[33mRed\u001b[0m\u001b[33m Hat\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m Container\u001b[0m\u001b[33m Platform\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Purchase\u001b[0m\u001b[33m and\u001b[0m\u001b[33m install\u001b[0m\u001b[33m the\u001b[0m\u001b[33m full\u001b[0m\u001b[33m Red\u001b[0m\u001b[33m Hat\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m platform\u001b[0m\u001b[33m.\n",
-      "\u001b[33m.\u001b[0m\u001b[33m **\u001b[0m\u001b[33mConfigure\u001b[0m\u001b[33m Your\u001b[0m\u001b[33m Cluster\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Configure\u001b[0m\u001b[33m your\u001b[0m\u001b[33m cluster\u001b[0m\u001b[33m by\u001b[0m\u001b[33m setting\u001b[0m\u001b[33m up\u001b[0m\u001b[33m a\u001b[0m\u001b[33m project\u001b[0m\u001b[33m,\u001b[0m\u001b[33m creating\u001b[0m\u001b[33m a\u001b[0m\u001b[33m namespace\u001b[0m\u001b[33m,\u001b[0m\u001b[33m and\u001b[0m\u001b[33m configuring\u001b[0m\u001b[33m networking\u001b[0m\u001b[33m.\n",
-      "\u001b[33m.\u001b[0m\u001b[33m **\u001b[0m\u001b[33mDeploy\u001b[0m\u001b[33m Applications\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Deploy\u001b[0m\u001b[33m applications\u001b[0m\u001b[33m to\u001b[0m\u001b[33m your\u001b[0m\u001b[33m cluster\u001b[0m\u001b[33m using\u001b[0m\u001b[33m one\u001b[0m\u001b[33m of\u001b[0m\u001b[33m the\u001b[0m\u001b[33m following\u001b[0m\u001b[33m methods\u001b[0m\u001b[33m:\n",
-      "\u001b[33m*\u001b[0m\u001b[33m **\u001b[0m\u001b[33mUsing\u001b[0m\u001b[33m YAML\u001b[0m\u001b[33m Manifest\u001b[0m\u001b[33ms\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Create\u001b[0m\u001b[33m a\u001b[0m\u001b[33m YAML\u001b[0m\u001b[33m file\u001b[0m\u001b[33m that\u001b[0m\u001b[33m defines\u001b[0m\u001b[33m your\u001b[0m\u001b[33m application\u001b[0m\u001b[33m's\u001b[0m\u001b[33m configuration\u001b[0m\u001b[33m and\u001b[0m\u001b[33m deploy\u001b[0m\u001b[33m it\u001b[0m\u001b[33m to\u001b[0m\u001b[33m the\u001b[0m\u001b[33m cluster\u001b[0m\u001b[33m.\n",
-      "\u001b[33m\t\u001b[0m\u001b[33m*\u001b[0m\u001b[33m **\u001b[0m\u001b[33mUsing\u001b[0m\u001b[33m the\u001b[0m\u001b[33m Web\u001b[0m\u001b[33m Console\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Use\u001b[0m\u001b[33m the\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m web\u001b[0m\u001b[33m console\u001b[0m\u001b[33m to\u001b[0m\u001b[33m deploy\u001b[0m\u001b[33m applications\u001b[0m\u001b[33m from\u001b[0m\u001b[33m a\u001b[0m\u001b[33m container\u001b[0m\u001b[33m image\u001b[0m\u001b[33m or\u001b[0m\u001b[33m a\u001b[0m\u001b[33m Git\u001b[0m\u001b[33m repository\u001b[0m\u001b[33m.\n",
-      "\u001b[33m\t\u001b[0m\u001b[33m*\u001b[0m\u001b[33m **\u001b[0m\u001b[33mUsing\u001b[0m\u001b[33m o\u001b[0m\u001b[33mdo\u001b[0m\u001b[33m Tool\u001b[0m\u001b[33m**:\u001b[0m\u001b[33m Use\u001b[0m\u001b[33m the\u001b[0m\u001b[33m `\u001b[0m\u001b[33modo\u001b[0m\u001b[33m`\u001b[0m\u001b[33m tool\u001b[0m\u001b[33m,\u001b[0m\u001b[33m which\u001b[0m\u001b[33m is\u001b[0m\u001b[33m a\u001b[0m\u001b[33m command\u001b[0m\u001b[33m-line\u001b[0m\u001b[33m interface\u001b[0m\u001b[33m for\u001b[0m\u001b[33m creating\u001b[0m\u001b[33m and\u001b[0m\u001b[33m deploying\u001b[0m\u001b[33m applications\u001b[0m\u001b[33m on\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m.\n",
+      "\u001b[0m\u001b[33m1\u001b[0m\u001b[33m.\u001b[0m\u001b[33m Launch\u001b[0m\u001b[33m your\u001b[0m\u001b[33m CRC\u001b[0m\u001b[33m instance\u001b[0m\u001b[33m and\u001b[0m\u001b[33m open\u001b[0m\u001b[33m the\u001b[0m\u001b[33m web\u001b[0m\u001b[33m console\u001b[0m\u001b[33m in\u001b[0m\u001b[33m your\u001b[0m\u001b[33m preferred\u001b[0m\u001b[33m web\u001b[0m\u001b[33m browser\u001b[0m\u001b[33m.\n",
+      "\u001b[0m\u001b[33m2\u001b[0m\u001b[33m.\u001b[0m\u001b[33m Select\u001b[0m\u001b[33m the\u001b[0m\u001b[33m \"\u001b[0m\u001b[33mDeveloper\u001b[0m\u001b[33m\"\u001b[0m\u001b[33m perspective\u001b[0m\u001b[33m.\n",
+      "\u001b[0m\u001b[33m3\u001b[0m\u001b[33m.\u001b[0m\u001b[33m Click\u001b[0m\u001b[33m on\u001b[0m\u001b[33m the\u001b[0m\u001b[33m \"\u001b[0m\u001b[33mAdd\u001b[0m\u001b[33m\"\u001b[0m\u001b[33m entry\u001b[0m\u001b[33m in\u001b[0m\u001b[33m the\u001b[0m\u001b[33m left\u001b[0m\u001b[33m-hand\u001b[0m\u001b[33m side\u001b[0m\u001b[33m menu\u001b[0m\u001b[33m.\n",
+      "\u001b[0m\u001b[33m4\u001b[0m\u001b[33m.\u001b[0m\u001b[33m Select\u001b[0m\u001b[33m the\u001b[0m\u001b[33m \"\u001b[0m\u001b[33mContainer\u001b[0m\u001b[33m Image\u001b[0m\u001b[33m\"\u001b[0m\u001b[33m option\u001b[0m\u001b[33m to\u001b[0m\u001b[33m deploy\u001b[0m\u001b[33m a\u001b[0m\u001b[33m container\u001b[0m\u001b[33m from\u001b[0m\u001b[33m a\u001b[0m\u001b[33m standard\u001b[0m\u001b[33m container\u001b[0m\u001b[33m registry\u001b[0m\u001b[33m.\n",
+      "\u001b[0m\u001b[33m5\u001b[0m\u001b[33m.\u001b[0m\u001b[33m Enter\u001b[0m\u001b[33m the\u001b[0m\u001b[33m URL\u001b[0m\u001b[33m of\u001b[0m\u001b[33m the\u001b[0m\u001b[33m ready\u001b[0m\u001b[33m-to\u001b[0m\u001b[33m-use\u001b[0m\u001b[33m container\u001b[0m\u001b[33m and\u001b[0m\u001b[33m click\u001b[0m\u001b[33m on\u001b[0m\u001b[33m the\u001b[0m\u001b[33m \"\u001b[0m\u001b[33mCreate\u001b[0m\u001b[33m\"\u001b[0m\u001b[33m button\u001b[0m\u001b[33m.\n",
       "\n",
-      "\u001b[33mNote\u001b[0m\u001b[33m:\u001b[0m\u001b[33m The\u001b[0m\u001b[33m specific\u001b[0m\u001b[33m steps\u001b[0m\u001b[33m may\u001b[0m\u001b[33m vary\u001b[0m\u001b[33m depending\u001b[0m\u001b[33m on\u001b[0m\u001b[33m your\u001b[0m\u001b[33m environment\u001b[0m\u001b[33m and\u001b[0m\u001b[33m requirements\u001b[0m\u001b[33m.\u001b[0m\u001b[33m It\u001b[0m\u001b[33m's\u001b[0m\u001b[33m recommended\u001b[0m\u001b[33m to\u001b[0m\u001b[33m refer\u001b[0m\u001b[33m to\u001b[0m\u001b[33m the\u001b[0m\u001b[33m official\u001b[0m\u001b[33m Red\u001b[0m\u001b[33m Hat\u001b[0m\u001b[33m documentation\u001b[0m\u001b[33m for\u001b[0m\u001b[33m detailed\u001b[0m\u001b[33m instructions\u001b[0m\u001b[33m.\u001b[0m\u001b[33m\u001b[0m"
+      "\u001b[0m\u001b[33mAlternatively\u001b[0m\u001b[33m,\u001b[0m\u001b[33m you\u001b[0m\u001b[33m can\u001b[0m\u001b[33m also\u001b[0m\u001b[33m use\u001b[0m\u001b[33m other\u001b[0m\u001b[33m methods\u001b[0m\u001b[33m such\u001b[0m\u001b[33m as\u001b[0m\u001b[33m:\n",
+      "\n",
+      "\u001b[0m\u001b[33m*\u001b[0m\u001b[33m Using\u001b[0m\u001b[33m the\u001b[0m\u001b[33m Developer\u001b[0m\u001b[33m Catalog\u001b[0m\u001b[33m to\u001b[0m\u001b[33m browse\u001b[0m\u001b[33m and\u001b[0m\u001b[33m choose\u001b[0m\u001b[33m from\u001b[0m\u001b[33m available\u001b[0m\u001b[33m databases\u001b[0m\u001b[33m,\u001b[0m\u001b[33m message\u001b[0m\u001b[33m queues\u001b[0m\u001b[33m,\u001b[0m\u001b[33m and\u001b[0m\u001b[33m other\u001b[0m\u001b[33m components\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33m*\u001b[0m\u001b[33m Spec\u001b[0m\u001b[33mifying\u001b[0m\u001b[33m the\u001b[0m\u001b[33m URL\u001b[0m\u001b[33m of\u001b[0m\u001b[33m a\u001b[0m\u001b[33m source\u001b[0m\u001b[33m code\u001b[0m\u001b[33m project\u001b[0m\u001b[33m stored\u001b[0m\u001b[33m on\u001b[0m\u001b[33m a\u001b[0m\u001b[33m Git\u001b[0m\u001b[33m repository\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33m*\u001b[0m\u001b[33m Import\u001b[0m\u001b[33ming\u001b[0m\u001b[33m YAML\u001b[0m\u001b[33m directly\u001b[0m\u001b[33m or\u001b[0m\u001b[33m even\u001b[0m\u001b[33m a\u001b[0m\u001b[33m J\u001b[0m\u001b[33mAR\u001b[0m\u001b[33m file\u001b[0m\u001b[33m with\u001b[0m\u001b[33m a\u001b[0m\u001b[33m Java\u001b[0m\u001b[33m application\u001b[0m\u001b[33m\n",
+      "\n",
+      "\u001b[0m\u001b[33mNote\u001b[0m\u001b[33m:\u001b[0m\u001b[33m You\u001b[0m\u001b[33m need\u001b[0m\u001b[33m to\u001b[0m\u001b[33m have\u001b[0m\u001b[33m Open\u001b[0m\u001b[33mShift\u001b[0m\u001b[33m installed\u001b[0m\u001b[33m and\u001b[0m\u001b[33m running\u001b[0m\u001b[33m before\u001b[0m\u001b[33m you\u001b[0m\u001b[33m can\u001b[0m\u001b[33m install\u001b[0m\u001b[33m it\u001b[0m\u001b[33m.\u001b[0m\u001b[33m\u001b[0m"
      ]
     }
    ],
    "source": [
     "queries = [\n",
-    "    \"How to install OpenShift?\",\n",
+    "    \"How do I install OpenShift?\",\n",
     "]\n",
     "\n",
     "for prompt in queries:\n",
@@ -301,13 +283,15 @@
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
-    "This tutorial demonstrates how to set up and use the built-in RAG tool for ingesting user-provided documents in a vector DB and later utilizing them during inference via direct retrieval. Please check out our [complementary tutorial]([Level3_agentic_RAG.ipynb](demos/rag_agentic/notebooks/Level3_agentic_RAG.ipynb) for an agentic RAG example."
+    "This notebook demonstrated how to set up and use the built-in RAG tool for ingesting user-provided documents in a vector database and utilizing them during inference via direct retrieval. \n",
+    "\n",
+    "Now that we've seen how easy it is to implement RAG with Llama Stack, We'll move on to building a simple agent with Llama Stack next in our [Simple Agents](./Level2_simple_agentic_with_websearch.ipynb) notebook."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -321,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/demos/rag_agentic/notebooks/Level1_foundational_RAG.ipynb
+++ b/demos/rag_agentic/notebooks/Level1_foundational_RAG.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook will show you how to build a simple RAG application with Llama Stack. You will learn how the API's provided by Llama Stack can be used to directly control and invoke all common RAG stages, including indexing, retrieval and inference. \n",
     "\n",
-    "_Note: This notebook contains a non-agentic implementation of RAG. We will show you how to build an agentic RAG application later in this tutorial in [Level3_agentic_RAG](demos/rag_agentic/notebooks/Level3_agentic_RAG.ipynb)._\n",
+    "_Note: This notebook contains a non-agentic implementation of RAG. We will show you how to build an agentic RAG application later in this tutorial in [Level4_agentic_RAG](Level4_agentic_RAG.ipynb)._\n",
     "\n",
     "## Overview\n",
     "\n",
@@ -49,7 +49,7 @@
    "id": "631e8c70-6f28-440b-b71a-85d4040ffac4",
    "metadata": {},
    "source": [
-    "Next, we will initialize our environment as described in detail in our [\"Getting Started\" notebook](demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb). Please refer to it for additional explanations."
+    "Next, we will initialize our environment as described in detail in our [\"Getting Started\" notebook](Level0_getting_started_with_Llama_Stack.ipynb). Please refer to it for additional explanations."
    ]
   },
   {

--- a/demos/rag_agentic/notebooks/Level2_simple_agentic_with_websearch.ipynb
+++ b/demos/rag_agentic/notebooks/Level2_simple_agentic_with_websearch.ipynb
@@ -6,40 +6,34 @@
    "source": [
     "# Level 2: Simple Agent with Web Search\n",
     "\n",
-    "Building on the foundation of RAG in Level 1, this tutorial marks the beginning of the agent-focused section of the series. Here, we introduce a simple agent using llama-stack agentic framework, enhanced with a single builtin web search tool. This capability allows the agent to retrieve up to date external documentation, which is an important step toward developing a more capable and autonomous agent.\n",
+    "This notebook will introduce how to build a simple agent using Llama Stack's agent framework, enhanced with a single tool: the builtin web search tool. This capability will  allow the agent to retrieve up to date external information beyond the limits of its training data. This is an important step toward developing a more capable and autonomous agent.\n",
     "\n",
     "## Overview\n",
     "\n",
-    "This tutorial walks you through how to build your own AI agent who can search the web following these steps:\n",
-    "1. Configuring an agent for tool use.\n",
-    "2. Running the agent.\n",
+    "This tutorial will walk you through how to build your own AI agent who can search the web:\n",
+    "\n",
+    "1. Configure a Llama Stack agent.\n",
+    "2. Enhance the agent by providing it access to a specific tool\n",
+    "2. Interact with the agent and tests its use of the web search tool.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
-    "Before starting, ensure you have the following:\n",
-    "- Access to a remote cluster or a local Podman setup.\n",
-    "- A Tavily API key is required. You can register for one at [https://tavily.com/](https://tavily.com/).\n",
-    "\n",
-    "\n",
-    "## Setting the Environment Variables\n",
-    "\n",
-    "Use the [`.env.example`](../../../.env.example) to create a new file called `.env` and ensure you add all the relevant environment variables below.\n",
-    "\n",
-    "In addition to the environment variables listed in the [\"Getting Started\" notebook](demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb), the following should be provided for this demo to run:\n",
-    " - `TAVILY_SEARCH_API_KEY`: your API key for tavily search."
+    "Before starting this notebook, ensure that you have:\n",
+    "- Followed the instructions in the [Setup Guide](./Level0_getting_started_with_Llama_Stack.ipynb) notebook. \n",
+    "- A Tavily API key. It is critical for this notebook to run correctly. You can register for one at [https://tavily.com/](https://tavily.com/)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Setting Up the Environment\n",
-    "We will start with a few imports needed for this demo only."
+    "## 1. Setting Up this Notebook\n",
+    "We will start with a few imports."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -65,7 +59,7 @@
      "text": [
       "Connected to Llama Stack server\n",
       "Inference Parameters:\n",
-      "\tModel: granite32-8b\n",
+      "\tModel: ibm-granite/granite-3.2-8b-instruct\n",
       "\tSampling Parameters: {'strategy': {'type': 'greedy'}, 'max_tokens': 4096}\n",
       "\tstream: False\n"
      ]
@@ -86,14 +80,7 @@
     "from src.utils import step_printer\n",
     "from termcolor import cprint\n",
     "\n",
-    "remote = os.getenv(\"REMOTE\", \"True\")\n",
-    "\n",
-    "if remote == \"False\":\n",
-    "    local_port = os.getenv(\"LOCAL_SERVER_PORT\", 8321)\n",
-    "    base_url = f\"http://localhost:{local_port}\"\n",
-    "else: # any value non equal to 'False' will be considered as 'True'\n",
-    "    base_url = os.getenv(\"REMOTE_BASE_URL\")\n",
-    "\n",
+    "base_url = os.getenv(\"REMOTE_BASE_URL\")\n",
     "\n",
     "# Tavily search API key is required for some of our demos and must be provided to the client upon initialization.\n",
     "# We will cover it in the agentic demos that use the respective tool. Please ignore this parameter for all other demos.\n",
@@ -141,14 +128,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Configuring an agent for tool use.\n",
-    "- **Agent Initialization**: \n",
+    "## 2. Configure an agent for tool use.\n",
     "\n",
-    "- Create an `Agent` instance with the desired model, instructions and tools.\"\n",
+    "- **Agent Initialization**: First we create an `Agent` instance with the desired LLM model, agent instructions and tools.\n",
     "\n",
     "- **Instructions**: The `instructions` parameter, also referred to as the system prompt, specifies the agent's role and behavior. In this example, the agent is configured as a helpful web search assistant. It is instructed to use a tool whenever a web search is required and to respond in a friendly and helpful tone.\n",
     "\n",
-    "- **Tools**: The `tools` parameter defines the tools available to the agent. In this case, the `builtin::websearch` tool is used, which enables the agent to perform web searches. This tool is essential for retrieving up-to-date information from the web. Internally, it leverages Tavily Search to execute the search queries efficiently.\n",
+    "- **Tools**: The `tools` parameter defines the tools available to the agent. In this case, the `builtin::websearch` tool is used, which enables the agent to perform web searches. This tool is essential for retrieving up-to-date information from the web.\n",
     "\n",
     "- **How It Works**: When a user query is provided, the agent processes the input and determines whether a tool is required to fulfill the request. If the query involves retrieving information from the web, the agent invokes the `builtin::websearch` tool. The tool interacts with Tavily Search to fetch real-time data, which is then processed and returned to the user in a friendly and helpful tone. This workflow ensures that the agent can handle a wide range of queries effectively.\n",
     "\n",
@@ -157,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,15 +162,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Running the agent.\n",
-    "- Define user prompts to interact with the agent.\n",
-    "- Use the agent to create a session and process user queries.\n",
-    "- Display the agent's responses for each query."
+    "## 3. Run the agent.\n",
+    "- Populate `user_prompts\" with questions that you would like to ask the agent.\n",
+    "- Create a unique agent session for this conversation so that it can store metadata and context history in the Llama Stack server.\n",
+    "- Finally, display the agent's responses for each query."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +358,7 @@
     "- **Green Text**: Indicates the tool execution process, such as the tool being called and the query being sent to the web search API.\n",
     "\n",
     "Great! \n",
-    "We can see that the model returned relevant and up-to-date information about OpenShift. This is particularly impressive given that the Granite 3.2 8B model, released in February 2025, has a knowledge cutoff of April 2024. These results were only possible due to its ability to call tools like web search, demonstrating the agent's capacity to retrieve real-time data effectively."
+    "We can see that the model returned relevant and up-to-date information about OpenShift. This is particularly impressive given that the Granite 3.2 8B model (that we are using here) was released in February 2025 and has a knowledge cutoff of April 2024. These results were only possible due to its ability to call tools like web search, demonstrating the agent's capacity to retrieve real-time data effectively."
    ]
   },
   {
@@ -381,17 +367,17 @@
    "source": [
     "## Key Takeaways\n",
     "\n",
-    "- Demonstrates how to set up and use the web search tool with an AI agent.\n",
-    "- Highlights the flexibility of running agents in both local and remote Kubernetes environments.\n",
-    "- Serves as a foundational example for more advanced workflows involving RAG, OCP, and MCP in subsequent levels.\n",
+    "- We've demonstrated how to set up Llama Stack agents and extended them with builtin tools (like web search) that come prepackaged with Llama Stack.\n",
+    "- We've shown that this simple approach can provide significantly increased functionality of existing open source LLM's. \n",
+    "- This will serves as a foundational example for the more advanced examples to come involving Agentic RAG, External Tools, and complex agentic patterns.\n",
     "\n",
-    "Continue to later notebooks for enhanced agent capabilities such as prompt chaining, ReAct reasoning, RAG integration, and multi-context deployment with MCP.\n"
+    "Continue to the [next notebook](./Level3_advance_agentic_with_Prompt_Chaining_ReAct.ipynb) to learn how we can upgrade our agents to solve even more complex and multi-step tasks using advanced agentic patterns. \n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "stackclientv24",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -405,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/demos/rag_agentic/notebooks/Level2_simple_agentic_with_websearch.ipynb
+++ b/demos/rag_agentic/notebooks/Level2_simple_agentic_with_websearch.ipynb
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we will initialize our environment as described in detail in our [\"Getting Started\" notebook](demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb). Please refer to it for additional explanations."
+    "Next, we will initialize our environment as described in detail in our [\"Getting Started\" notebook](Level0_getting_started_with_Llama_Stack.ipynb). Please refer to it for additional explanations."
    ]
   },
   {
@@ -163,7 +163,7 @@
    "metadata": {},
    "source": [
     "## 3. Run the agent.\n",
-    "- Populate `user_prompts\" with questions that you would like to ask the agent.\n",
+    "- Populate `user_prompts` with questions that you would like to ask the agent.\n",
     "- Create a unique agent session for this conversation so that it can store metadata and context history in the Llama Stack server.\n",
     "- Finally, display the agent's responses for each query."
    ]

--- a/demos/rag_agentic/notebooks/requirements.txt
+++ b/demos/rag_agentic/notebooks/requirements.txt
@@ -1,0 +1,2 @@
+llama-stack==0.2.4
+geocoder


### PR DESCRIPTION
The majority of the changes in this PR are edits to the markdown text and instructions in notebooks 0, 1, and 2 in the `rag_agentic` demo. 

Other Changes include:
* Added default values to the `.env.example` file.
* Removed the use of `REMOTE` and `LOCAL_SERVER_PORT` env variables in favor of simply having the Llama Stack server always point to `REMOTE_BASE_URL` for each notebook. This should make things simpler for users.  
* Added a `requirements.txt` file to the `notebooks/` directory and changed the `! pip install ...` cell to use `requirements.txt` instead of specifying specific package names. This should make this demo more maintainable over time.    