### PR TITLE
update level2 and level3 with correct imports

### DIFF
--- a/demos/rag_agentic/notebooks/Level2_simple_agentic_with_websearch.ipynb
+++ b/demos/rag_agentic/notebooks/Level2_simple_agentic_with_websearch.ipynb
@@ -33,11 +33,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_stack_client.lib.agents.agent import Agent\n",
+    "from llama_stack_client import Agent\n",
     "from llama_stack_client.lib.agents.event_logger import EventLogger"
    ]
   },

--- a/demos/rag_agentic/notebooks/Level3_advance_agentic_with_Prompt_Chaining_ReAct.ipynb
+++ b/demos/rag_agentic/notebooks/Level3_advance_agentic_with_Prompt_Chaining_ReAct.ipynb
@@ -36,11 +36,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_stack_client.lib.agents.agent import Agent\n",
+    "from llama_stack_client import Agent\n",
     "from llama_stack_client.lib.agents.event_logger import EventLogger\n",
     "from llama_stack_client.lib.agents.react.agent import ReActAgent\n",
     "from llama_stack_client.lib.agents.react.tool_parser import ReActOutput\n",


### PR DESCRIPTION
Level2 and Level3 notebooks are using the old version of importing the `Agent` module, updating it to be consistent with the other notebooks
