### PR TITLE
fix: fixed broken links in Notebook 5.

### DIFF
--- a/demos/rag_agentic/notebooks/Level5_agents_and_mcp.ipynb
+++ b/demos/rag_agentic/notebooks/Level5_agents_and_mcp.ipynb
@@ -25,12 +25,12 @@
     "\n",
     "Throughout this notebook we will be relying on the [kuberenetes-mcp-server](https://github.com/manusa/kubernetes-mcp-server) by [manusa](https://github.com/manusa) to interact with our OpenShift cluster. Please see installation instructions below if you do not already have this deployed in your environment. \n",
     "\n",
-    "* [OpenShift MCP installation instructions](../../../mcp-servers/openshift/README.md)\n",
+    "* [OpenShift MCP installation instructions](../../../kubernetes/mcp-servers/openshift-mcp/README.md)\n",
     "\n",
     "#### Slack MCP Server\n",
     "We will also be using the [Slack MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/slack) in this notebook. Please see installation instructions below if you do not already have this deployed in your environment. \n",
     "\n",
-    "* [Slack MCP installation instructions](../../../mcp-servers/slack/README.md)"
+    "* [Slack MCP installation instructions](../../../kubernetes/mcp-servers/slack-mcp/README.md)"
    ]
   },
   {
@@ -41,12 +41,12 @@
     "## Pre-Requisites\n",
     "\n",
     "Before starting this notebook, ensure that you have:\n",
-    "- Followed the instructions in the [Setup Guide](./Level0_getting_started_with_Llama_Stack.ipynb) notebook. \n",
-    "- Access to an OpeShift cluster with a deployment of the [OpenShift MCP server](https://github.com/opendatahub-io/llama-stack-on-ocp/tree/main/mcp-servers/openshift) (see the [deployment manifests](https://github.com/opendatahub-io/llama-stack-on-ocp/tree/main/kubernetes/mcp-servers/openshift-mcp) for assistance with this).\n",
-    "- A Tavily API key is required. You can register for one at https://tavily.com/home.\n",
+    "- Followed the instructions in the [Setup Guide](./Level0_getting_started_with_Llama_Stack.ipynb) notebook.\n",
+    "- Access to an OpeShift cluster with a deployment of the [OpenShift MCP server](https://github.com/opendatahub-io/llama-stack-demos/tree/main/kubernetes/mcp-servers/openshift-mcp) (see the [deployment manifests](https://github.com/opendatahub-io/llama-stack-on-ocp/tree/main/kubernetes/mcp-servers/openshift-mcp) for assistance with this).\n",
+    "- A Tavily API key is required. You can register for one at https://app.tavily.com/home.\n",
     "\n",
     "## Setting Up this Notebook\n",
-    "We will initialize our environment as described in detail in our [\"Getting Started\" notebook](demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb). Please refer to it for additional explanations."
+    "We will initialize our environment as described in detail in our [\"Getting Started\" notebook](./Level0_getting_started_with_Llama_Stack.ipynb). Please refer to it for additional explanations."
    ]
   },
   {
@@ -395,7 +395,7 @@
    "source": [
     "## Key Takeaways\n",
     "\n",
-    "This notebook demonstrated how to build an agentic MCP applications with Llama Stack. We did this by initializing an agent with access to two MCP servers that were registered to our Llama Stack server, then invoked the agent on our specified set of queries. Please check out our next notebooks, [Agentic MCP and RAG](Levl6_agents_MCP_and_RAG.ipynb) for more examples of extending your agents capabilities with Llama Stack."
+    "This notebook demonstrated how to build an agentic MCP applications with Llama Stack. We did this by initializing an agent with access to two MCP servers that were registered to our Llama Stack server, then invoked the agent on our specified set of queries. Please check out our next notebooks, [Agentic MCP and RAG](./Level6_agents_MCP_and_RAG.ipynb) for more examples of extending your agents capabilities with Llama Stack."
    ]
   }
  ],


### PR DESCRIPTION
Fix: Update MCP Server Installation Paths and Tavily API Link

## Description
This pull request updates several file paths and a URL to ensure they are accurate and up-to-date. Specifically:

-   Corrected the file paths for OpenShift and Slack MCP server installation instructions. The paths were updated from `../../../mcp-servers/openshift/README.md` to `../../../kubernetes/mcp-servers/openshift-mcp/README.md` and from `../../../mcp-servers/slack/README.md` to `../../../kubernetes/mcp-servers/slack-mcp/README.md`.
-   Updated the Tavily API key registration link from `https://tavily.com/home` to `https://app.tavily.com/home`.
-    Corrected the relative path for the "Getting Started" notebook link from `demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb` to `./Level0_getting_started_with_Llama_Stack.ipynb`.

These changes ensure that users are directed to the correct resources and installation instructions, and that the notebook functions as expected.

## How Has This Been Tested?
1.  **Manual Verification of Links:** I manually clicked on the updated links for the OpenShift MCP server, Slack MCP server, and Tavily API key in a local environment to confirm they resolve to the correct pages.
2.  **Notebook Testing:** I opened the relevant notebook and verified that the link to the "Getting Started" notebook is working correctly.
3.  **Contextual Review:** I reviewed the surrounding text to ensure the updated paths and URLs are appropriate within the context of the documentation.

## Merge criteria:
-   [x] The commits are squashed in a cohesive manner and have meaningful messages.
-   [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
-   [x] The developer has manually tested the changes and verified that the changes work.
