### PR TITLE
Update .env.example to set max tokens to 512

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ REMOTE_BASE_URL= "http://localhost:8321"
 # optional environment variables for all demos
 TEMPERATURE="0.0"
 TOP_P="0.95"
-MAX_TOKENS="4096"
+MAX_TOKENS="512"
 STREAM="False"
 
 # for the RAG demos only - mandatory


### PR DESCRIPTION
This change make notebook 6 work in 1 click otherwise it throws an error in the last cell (followed the instructions command to create the .env: `cp .env.example .env`)

## How Has This Been Tested?
Ran all notebooks after making the change and they return the same output as before. Notebook 6 finishes without an error. 