### PR TITLE
Add UX improvements to notebook 0 and env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 LLM_AS_JUDGE_MODEL_ID= ""
 
 # mandatory unless a local deployment is used
-REMOTE_BASE_URL= "http://localhost:8321"
+REMOTE_BASE_URL= "http://llamastack-server:8321"
 
 # optional environment variables for all demos
 TEMPERATURE="0.0"

--- a/demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb
+++ b/demos/rag_agentic/notebooks/Level0_getting_started_with_Llama_Stack.ipynb
@@ -35,17 +35,7 @@
    "execution_count": 1,
    "id": "ba0ddc8b-d6cf-4cb3-8678-7b52ee70131e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! pip install -r requirements.txt > /dev/null"
    ]
@@ -100,12 +90,7 @@
     "\n",
     "# for communication with Llama Stack\n",
     "from llama_stack_client import LlamaStackClient\n",
-    "\n",
-    "# pretty print of the results returned from the model/agent\n",
-    "import sys\n",
-    "sys.path.append('..')  \n",
-    "from src.utils import step_printer\n",
-    "from termcolor import cprint"
+    "from llama_stack_client.types import UserMessage"
    ]
   },
   {
@@ -135,7 +120,7 @@
     }
    ],
    "source": [
-    "base_url = os.getenv(\"REMOTE_BASE_URL\", \"http://localhost:8321\")\n",
+    "base_url = os.getenv(\"REMOTE_BASE_URL\", \"http://llamastack-server:8321\")\n",
     "\n",
     "# Tavily search API key is required for some of our demos and must be provided to the client upon initialization.\n",
     "# We will cover it in the agentic demos that use the respective tool. Please ignore this parameter for all other demos.\n",
@@ -175,7 +160,7 @@
      "output_type": "stream",
      "text": [
       "Inference Parameters:\n",
-      "\tSampling Parameters: {'strategy': {'type': 'greedy'}, 'max_tokens': 4096}\n",
+      "\tSampling Parameters: {'strategy': {'type': 'greedy'}, 'max_tokens': 512}\n",
       "\tstream: False\n"
      ]
     }
@@ -202,6 +187,44 @@
     "stream = (stream_env != \"False\")\n",
     "\n",
     "print(f\"Inference Parameters:\\n\\tSampling Parameters: {sampling_params}\\n\\tstream: {stream}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5cdd34a",
+   "metadata": {},
+   "source": [
+    "Now, let's use the Llama stack inference API to greet our LLM. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9e4423b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"I'm an artificial intelligence and don't have feelings, but I'm here to help you. How can I assist you today?\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "message = UserMessage(\n",
+    "    content=\"Hi, how are you?\",\n",
+    "    role=\"user\",\n",
+    ")\n",
+    "client.inference.chat_completion(\n",
+    "    model_id=\"granite32-8b\",\n",
+    "    messages=[message],\n",
+    "    sampling_params=sampling_params,\n",
+    "    stream=stream\n",
+    ").completion_message.content"
    ]
   },
   {


### PR DESCRIPTION
The PR adds two changes:

- Set REMOTE_BASE_URL="http://llamastack-server:8321/"   in the .env.example so that it's directly usable in the notebooks with the demo env llama stack server.

- Add a simple client.inference.chat_completion("Hi, how are you?") to notebook 0 to confirm that the client was able to connect to the LLS APIs.
