### PR TITLE
Add slack mcp server to run.yaml

### DIFF
--- a/kubernetes/llama-stack/run.yaml
+++ b/kubernetes/llama-stack/run.yaml
@@ -131,3 +131,7 @@ tool_groups:
   provider_id: model-context-protocol
   mcp_endpoint:
     uri: "http://ocp-mcp-server:8000/sse"
+- toolgroup_id: mcp::slack
+  provider_id: model-context-protocol
+  mcp_endpoint:
+    uri: "http://slack-mcp-server:8080/sse"


### PR DESCRIPTION
If the LLS server doesn't have the slack MCP server registered at runtime, then Level 5 and Level 6 notebooks will fail to run unless the user updates the Slack MCP URL in the env file.  OpenShift MCP server already comes pre-registered.


## How Has This Been Tested?
@cooktheryan I don't see a reason why this shouldn't work but I don't know an easy way to test this. 