### PR TITLE
updated localhost/distribution-ollama tag from 0.2.6 to 0.2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ run_mcp_container:
 
 setup_local:
 	ollama run llama3.2:3b-instruct-fp16 --keepalive 160m &
-	podman run -it -p 8321:8321 -v ~/.llama:/root/.llama localhost/distribution-ollama:0.2.6 --port 8321 --env INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct" --env OLLAMA_URL=http://host.containers.internal:11434
+	podman run -it -p 8321:8321 -v ~/.llama:/root/.llama localhost/distribution-ollama:0.2.7 --port 8321 --env INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct" --env OLLAMA_URL=http://host.containers.internal:11434


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
after running `make setup_local`, the tag for image `localhost/distribution-ollama` is `0.2.7`, not `0.2.6`. Leading to this error
```
Error: internal error: unable to copy from source docker://localhost/distribution-ollama:0.2.6: initializing source docker://localhost/distribution-ollama:0.2.6: pinging container registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused
```

output after listing images
```
llama-stack-demos % podman images
REPOSITORY                                  TAG         IMAGE ID      CREATED             SIZE
localhost/distribution-ollama               0.2.7       aee055501a88  About a minute ago  1.49 GB
localhost/streamlit_client                  latest      d1a8e39c318e  47 minutes ago      1.61 GB
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
