### PR TITLE
fixed client configuration endpoint command to use host machine's network

### DIFF
--- a/local_setup_guide.md
+++ b/local_setup_guide.md
@@ -95,7 +95,7 @@ pip list | grep llama-stack-client
 ## **6. Configure the Client**
 Set up the client to connect to the Llama Stack server:
 ```bash
-llama-stack-client configure --endpoint http://localhost:$LLAMA_STACK_PORT
+llama-stack-client configure --endpoint http://host.containers.internal:$LLAMA_STACK_PORT
 ```
 List available models:
 ```bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the hostname from `localhost` to `host.containers.internal`. This ensures that the Streamlit_client, running inside a container, can correctly connect to the Llama Stack server, which is running in a separate container and exposed via the host network.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
