### PR TITLE
fix: updated httpcore from 1.0.8 to 1.0.9

### DIFF
--- a/demos/a2a_llama_stack/requirements.txt
+++ b/demos/a2a_llama_stack/requirements.txt
@@ -4,7 +4,7 @@ certifi==2025.1.31
 click==8.1.8
 distro==1.9.0
 h11==0.16.0
-httpcore==1.0.8
+httpcore==1.0.9
 httpx==0.28.1
 idna==3.10
 llama_stack_client==0.2.2


### PR DESCRIPTION
Was having this error before:
ERROR: Cannot install -r requirements.txt (line 7) and h11==0.16.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested h11==0.16.0
    httpcore 1.0.8 depends on h11<0.15 and >=0.13

Updated httpcore to 1.0.9 so it is comptable with h11 0.16.0

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
