### PR TITLE
allow for llama to run on l4

### DIFF
--- a/kubernetes/kustomize/overlay/demo/kustomization.yaml
+++ b/kubernetes/kustomize/overlay/demo/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   # llama-serve resources
-  - ../../../llama-serve/granite-8b
+  - ../../../llama-serve/llama3.2-3b
   - ../../../mcp-servers/slack-mcp
 
 patchesStrategicMerge:

--- a/kubernetes/llama-serve/llama3.2-3b/servingruntime.yaml
+++ b/kubernetes/llama-serve/llama3.2-3b/servingruntime.yaml
@@ -26,7 +26,7 @@ spec:
         - '--chat-template'
         - /app/data/template/tool_chat_template_llama3.2_json.jinja
         - '--max-model-len'
-        - '120000'
+        - '110000'
       command:
         - python
         - '-m'


### PR DESCRIPTION
As discussed during the call today. We will host llama on L4 smaller AWS instances and use granite from MAAS. A follow up PR will be produced to move the configuration of the granite using MAAS.
